### PR TITLE
added reactive dark mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -150,6 +150,7 @@ body {
     align-items: center;
     background-color: #f43f5e;
     color: #ffffff;
+    cursor: pointer;
 }
 
 #toggle-mode-btn svg {

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,12 @@
 const toggleModeBtn = document.getElementById("toggle-mode-btn");
+const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)");
+
+if (prefersDarkScheme.matches) {
+  document.documentElement.setAttribute("data-theme", "dark");
+} else {
+  document.documentElement.setAttribute("data-theme", "light");
+}
+
 toggleModeBtn.onclick = () => {
     if (document.documentElement.getAttribute("data-theme") === "light") {
         document.documentElement.setAttribute("data-theme", "dark");


### PR DESCRIPTION
Site loads directly into dark mode by default if the user already have it enabled and loads into light mode when light mode is enabled.
Detects dark mode using ```prefers-color-scheme``` css media feature and injects appropriate class with javascript

https://user-images.githubusercontent.com/54097365/193818784-bd9ff26b-a0f5-4f2d-b1fb-e25b1552704f.mov

