### PR TITLE
CSS : Github Icon Added

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -73,6 +73,13 @@ body {
     padding: 0.8rem 1rem;
 }
 
+/* github icon added here */
+.github-icon{
+    font-size: 1.2rem;
+    justify-content: center;
+    align-items: center;
+}
+
 .projects-container {
     max-width: 1080px;
     display: grid;

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/remixicon@4.3.0/fonts/remixicon.css" rel="stylesheet"/>
+
 
     <title>Master web development</title>
 </head>
@@ -34,7 +36,7 @@
             <p>Master web development</p>
             <h3><span>Open</span> Projects</h3>
             <div class="btn-container">
-                <a href="http://github.com/iamrahulmahato/master-web-development" target="_blank" rel="noopener noreferrer" class="source-code-btn">View source code</a>
+                <a href="http://github.com/iamrahulmahato/master-web-development" target="_blank" rel="noopener noreferrer" class="source-code-btn">View source code <i class="ri-github-fill github-icon"></i></a>
             </div>
         </div>
 


### PR DESCRIPTION
## Added Github Icon
Fixes #134 

## Added Github icon from Remix icon.
- Few changes made in css

## Light Mode 
![image](https://github.com/user-attachments/assets/03e332f4-1902-4ca7-bcd9-f5b7e540c2d3)

## Dark Mode 
![image](https://github.com/user-attachments/assets/35a43fc5-864e-4770-b63b-f00c51e22dea)
