### PR TITLE
increase or decrease count when you long-press the + and - buttons

### DIFF
--- a/projects/counter/index.html
+++ b/projects/counter/index.html
@@ -22,22 +22,50 @@
         const incr = document.querySelector('.incr')
         const decr = document.querySelector('.decr')
         let count = 0;
+        let interval;
 
         // Function to update the counter display
         const updateCounter = () => {
             counter.innerHTML = count;
         };
 
-        // Button click events
-        incr.addEventListener("click", () => {
-            count += 1;
-            updateCounter();
-        });
+        // Function to start incrementing
+        const startIncrement = () => {
+            interval = setInterval(() => {
+                count += 1;
+                updateCounter();
+            }, 100); 
+        };
 
-        decr.addEventListener("click", () => {
-            count -= 1;
-            updateCounter();
-        });
+        // Function to start decrementing
+        const startDecrement = () => {
+            interval = setInterval(() => {
+                count -= 1;
+                updateCounter();
+            }, 100); 
+        };
+
+        // Stop the increment or decrement when the button is released
+        const stop = () => {
+            clearInterval(interval);
+        };
+
+        // Button events for increment
+        incr.addEventListener("mousedown", startIncrement);
+        incr.addEventListener("mouseup", stop);
+        incr.addEventListener("mouseleave", stop);
+
+        // Button events for decrement
+        decr.addEventListener("mousedown", startDecrement);
+        decr.addEventListener("mouseup", stop);
+        decr.addEventListener("mouseleave", stop);
+
+        // For mobile/touch devices
+        incr.addEventListener("touchstart", startIncrement);
+        incr.addEventListener("touchend", stop);
+
+        decr.addEventListener("touchstart", startDecrement);
+        decr.addEventListener("touchend", stop);
 
         // Keyboard event listener
         document.addEventListener("keydown", (event) => {


### PR DESCRIPTION
### Summary
Added functionality to handle long press events for incrementing and decrementing the counter in the HTML-based counter component.

### Changes Made
- Added `setInterval` and `clearInterval` to continuously update the counter on long press of the `+` and `-` buttons.
- Ensured compatibility with both desktop (mouse events) and mobile devices (touch events).

### How to Test
1. Press and hold the `+` or `-` button.
2. Observe the counter increasing or decreasing continuously while the button is held.
3. Release the button to stop the counting.
4. Works on both desktop and mobile.

