### PR TITLE
Updated the GitHub Profile Viewer

### DIFF
--- a/projects/githubProfileViewer/index.html
+++ b/projects/githubProfileViewer/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Github Profile Viewer</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
Changes I did remove the **_Document_** from <title> added **GitHub Profile Viewer** to <title>

**BEFORE** ❌❌
![Screenshot 2024-10-06 111208](https://github.com/user-attachments/assets/18a5fec5-f357-466c-a480-a0ffdd51002a)

**AFTER** ✅✅
![image](https://github.com/user-attachments/assets/45626701-f992-4b1b-9c3c-c18e61199829)


Fixed the Issue #490

Please give me hacktober and hacktober-accepted labels