### PR TITLE
Updated: "m" to "cm" in BMI Calculator

### DIFF
--- a/projects/bmi calculator/index.html
+++ b/projects/bmi calculator/index.html
@@ -28,7 +28,7 @@
             <input type="text" required id="height">
             <span class="highlight"></span>
             <span class="bar"></span>
-            <label>Height(m)</label>
+            <label>Height(cm)</label>
         </div>
         <button id="calculate">Calculate</button>
 


### PR DESCRIPTION
fixes: #487
Changed label of height parameter **_"m"_**  to **_"cm"_** in BMI Calculator.

![image](https://github.com/user-attachments/assets/7be4ad4a-527b-47de-a072-dc4be0b44643)
