### PR TITLE
Fixed issue #330: Wrong Redirection in Home Page for Number Guessing game

### DIFF
--- a/community/frontend/index.html
+++ b/community/frontend/index.html
@@ -219,7 +219,7 @@
                     </p>
                 </div>
             </a>
-            <a href="./projects/Number%20Guessing/index.html" class="card">
+            <a href="./projects/Number guessing/index.html" class="card">
                 <div class="card-cover counter-cover-colour">
                     <img src="./assets/image/number_guessing.jpg" alt="number guessing">
                 </div>

--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
                 </div>
             </a>
 
-            <a href="./projects/Number%20guessinguessing/index.html" class="card" target="_blank">
+            <a href="./projects/Number guessing/index.html" class="card" target="_blank">
                 <div class="card-cover counter-cover-colour">
                     <img src="./assets/image/numbers.png" alt="number guessing">
                 </div>


### PR DESCRIPTION
There was a mistake in the anchor tag for the Number Guessing element in the Home page of the project, that's why when any user clicks the button to get to the game, it is redirecting them to a not found page.

The wrong redirected page URL was: `https://master-web-development.netlify.app/projects/Number%20guessinguessing/index.html` .
But the correct URL should be : `https://master-web-development.netlify.app/projects/Number%20guessing/index.html`.

So, I fixed the issue by changing the href in the anchor tag of the index.html or the home page of the project, And now it works fine, as it should be.

Thank you for giving me this opportunity to contribute to your repository. Also kindly assign the gssoc-ext and hacktoberfest labels with the PR.

I'm also attaching the screen recording of the project with the bug and also after fixing the bug.

With the bug:
[Screencast from 07-10-24 09:52:50 PM IST.webm](https://github.com/user-attachments/assets/4d948062-33fd-4d6c-8e7f-f3c459fe7478)

After the fix:
[Screencast from 07-10-24 09:53:52 PM IST.webm](https://github.com/user-attachments/assets/8a9d871e-7abf-42e0-a740-01b974f933f7)


