### PR TITLE
Created Terms of Use page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2485,7 +2485,7 @@
             <li><a href="">Help Centre</a></li>
             <li><a href="">Account</a></li>
             <li><a href="">Media Centre</a></li>
-            <li><a href="">Terms of use</a></li>
+            <li><a href="terms.html">Terms of use</a></li>
             <li><a href="privacy.html">Privacy</a></li>
             <li><a href="">Cookie Preferences</a></li>
             <li><a href="">Contact Us</a></li>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms Of Use - Master Web Development</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            line-height: 1.7;
+            margin: 0;
+            padding: 0;
+            background-color: rgb(248,250,252);
+            color: #333;
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 50px auto;
+            padding: 30px;
+            background: #ffffff;
+            border-radius: 15px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        }
+
+        h1 {
+            text-align: center;
+            font-size: 2.8rem;
+            color: #34495e;
+            margin-bottom: 20px;
+            border-bottom: 2px solid #3498db;
+            display: inline-block;
+            padding-bottom: 5px;
+        }
+
+        h2 {
+            color: #2c3e50;
+            margin-top: 30px;
+            font-size: 1.8rem;
+            position: relative;
+        }
+
+        h2:before {
+            content: '';
+            position: absolute;
+            height: 2px;
+            width: 50px;
+            background-color: #3498db;
+            bottom: -5px;
+            left: 0;
+        }
+
+        p {
+            font-size: 1.1rem;
+            color: #555;
+            margin-bottom: 15px;
+        }
+
+        ul {
+            margin-left: 20px;
+            margin-bottom: 20px;
+            color: #444;
+        }
+
+        ul li {
+            margin-bottom: 10px;
+        }
+
+        a {
+            color: #3498db;
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        a:hover {
+            color: #1abc9c;
+            text-decoration: underline;
+        }
+
+        .button {
+            display: inline-block;
+            padding: 10px 20px;
+            margin-top: 20px;
+            background-color: #3498db;
+            color: #ffffff;
+            text-align: center;
+            border-radius: 5px;
+            text-decoration: none;
+            font-size: 1rem;
+            transition: background-color 0.3s ease;
+        }
+
+        .button:hover {
+            background-color: #1abc9c;
+        }
+
+        /* Adding some spacing between sections */
+        .section-spacing {
+            margin-bottom: 40px;
+        }
+
+        /* Style for the terms details */
+        .terms-content {
+            padding: 20px;
+            background-color: #f4f8fb;
+            border-left: 5px solid #3498db;
+            margin-top: 20px;
+            border-radius: 10px;
+        }
+
+        /* Styling for the effective date */
+        .effective-date {
+            color: #555;
+            font-weight: bold;
+            margin-bottom: 20px;
+        }
+
+        @media (max-width: 768px) {
+            .container {
+                padding: 20px;
+            }
+
+            h1 {
+                font-size: 2.2rem;
+            }
+
+            h2 {
+                font-size: 1.6rem;
+            }
+
+            p {
+                font-size: 1rem;
+            }
+
+            .button {
+                font-size: 0.9rem;
+            }
+        }
+    </style>
+</head>
+
+<body>
+
+    <div class="container">
+        <h1>Terms of Use</h1>
+
+        <h2>Introduction</h2>
+        <div class="terms-content">
+            <p>
+                Welcome to Master web development. These Terms of Service ("Terms") 
+                govern your use of our website and any services, content, 
+                and features offered through the Site (collectively, the "Services"). 
+                By accessing or using our Services, you agree to be bound by these 
+                Terms. If you do not agree to these Terms, please do not use our 
+                Services.
+              </p>
+            
+        </div>
+
+        <h2>Eligibility</h2>
+        <div class="terms-content">
+            <p>You must be at least [minimum age, e.g., 13 years] old to use our 
+                Services. By using our Services, you represent and warrant that 
+                you meet this age requirement.
+            </p>
+            
+        </div>
+
+        <h2>Use of Services</h2>
+        <div class="terms-content">
+            <p>You agree to use the Services only for lawful purposes and in accordance
+                 with these Terms. You agree not to:</p>
+                 <ul>
+                    <li>1. Use the Services in any way that violates any applicable federal, state, local, or international law or regulation. </li>
+                    <li>2. Impersonate or attempt to impersonate Master web development, a Master web development employee, another user, or any other person or entity.</li>
+                    <li>3. Engage in any other conduct that restricts or inhibits anyone's use or enjoyment of the Services, or which, as determined 
+                        by us, may harm Master web development or users of the Services or expose them to liability.</li>
+                </ul>
+        </div>
+
+        <h2>Third-Party Services</h2>
+        <div class="terms-content">
+            <p>We may use third-party services to assist us in operating our website. These services have their own
+                Terms of Use, and we recommend reviewing them to understand how they handle your data.</p>
+        </div>
+
+        <h2>Changes to the Terms</h2>
+        <div class="terms-content">
+            <p>We may modify these Terms from time to time. We will notify you of any changes by posting
+                 the new Terms on this page with a new effective date. You are advised to review these 
+                 Terms periodically for any changes. Your continued use of the Services after any 
+                 modifications to the Terms will constitute your acknowledgment of the modifications 
+                 and your consent to abide by and be bound by the modified Terms.</p>
+        </div>
+
+
+        <h2>Contact Us</h2>
+        <div class="terms-content">
+            <p>If you have any questions about this Privacy terms, please contact us at:</p>
+            <p>Email: <a href="mailto:info@masterwebdev.com">info@masterwebdev.com</a></p>
+        </div>
+
+        <div class="section-spacing">
+            <a href="/" class="button">Return to Home</a>
+        </div>
+    </div>
+
+</body>
+
+</html>


### PR DESCRIPTION
Fixed issue #1564 

**Description**

This PR addresses the Updation of footer links to the new Terms of Use page and created a separate page for Terms of Use.

**Video**


https://github.com/user-attachments/assets/93a542ad-7329-4509-8fca-74b5617053ef


How I Solved It:

- Identified the broken link in the footer of the website.
- Created a new Terms of Use page.
- Updated the footer to link to the new Terms of Use page.
