### PR TITLE
Enhanced Footer with Social Links ON README

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,3 +320,10 @@ Please note that Open Source Design has a [Contributor Code of Conduct](./CODE_O
 
 </div>
 
+## Connect with Us 🤝
+
+Thank you for exploring this project! We’d love to connect and hear from you. Reach out through any of the platforms below:
+
+[![Email](https://img.shields.io/badge/Email-D14836?style=for-the-badge&logo=gmail&logoColor=white)](mailto:iamrahulmhto@gmail.com)
+[![GitHub](https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white)](https://github.com/iamrahulmahato)
+


### PR DESCRIPTION
**Closes: #1737**

## Description
The current README lacks an engaging and consistent footer section with social media links. The goal is to create a visually appealing footer at the end of the README that includes clickable icons for different social media platforms, encouraging better engagement and easy access to contact links.

**Issue_Reference: #1737**
---

![Screenshot 2024-10-28 152633](https://github.com/user-attachments/assets/8b45d677-d8a4-4502-bd7f-44a0f4b417a2)

