### PR TITLE
Colour scheme changed under the title Organize project changed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -156,8 +156,8 @@ body {
   padding: 10px 20px;
   cursor:pointer;
   transition:all 0.3s ease;
-  /* background-color: #0066cc; */
-  color: white;
+   background-color: #5f25a7; 
+  color: rgb(255, 255, 255);
   text-decoration: none;
   border-radius: 5px;
   font-family: Arial, sans-serif;
@@ -165,8 +165,8 @@ body {
 }
 
 .source-code-btn:hover {
-  /* background-color: #0052a3; */
-  color: black;
+   background-color: #fa2b4d; 
+  color: rgb(241, 243, 239);
 }
 
 .search-container {


### PR DESCRIPTION
The text on buttons under the title Organize projects previously was not visible. Thus I changed the colour scheme of the button as well as hover in a way that it suits both light as well as dark mode and matches with the colour scheme of the website.

Fixes#1993

Before:
![Screenshot 2024-11-02 140601](https://github.com/user-attachments/assets/7bcbfba7-9965-4220-91ba-fda802f776d3)
![Screenshot 2024-11-02 140613](https://github.com/user-attachments/assets/ec5e987c-83c8-45f5-80a8-c3054b26a825)


After:
![Screenshot 2024-11-02 140707](https://github.com/user-attachments/assets/5ea76055-2611-4826-951d-e2d9309fa8fb)
![Screenshot 2024-11-02 140718](https://github.com/user-attachments/assets/6106fe82-6940-499c-a3a1-b5d32f9310b1)


I hope the constribution made was useful!