### PR TITLE
FAQ section in Dark Mode Resolved

### DIFF
--- a/index.html
+++ b/index.html
@@ -3590,6 +3590,17 @@ body {
             margin-bottom: 20px;
             font-size: 2rem;
         }
+
+        [data-theme="dark"] #faq,
+        [data-theme="dark"] #faq h2{
+            background-color: black;
+            color:white;
+        }
+
+        [data-theme="dark"] .faq-item h3,
+        [data-theme="dark"] .faq-item p{
+            color:white;
+        }
         
         .faq-item {
             margin-bottom: 15px;


### PR DESCRIPTION
The FAQ was in light theme even under the Dark Mode. Now, The Styling has been done and the Dark Mode is perfectly fine for the FAQ section.

Closes:
#2055 FAQ section is in light theme even under Dark Mode